### PR TITLE
Fix mkdtemp suffix when containing slashes

### DIFF
--- a/pgdump-sort
+++ b/pgdump-sort
@@ -162,7 +162,7 @@ def recombine(destdir, dump):
 
 
 def pgdump_sort(dump, sdump):
-	destdir = tempfile.mkdtemp(suffix=dump, prefix='pgdump-sort')
+	destdir = tempfile.mkdtemp(suffix=os.path.basename(dump), prefix='pgdump-sort')
 
 	dissect(dump, destdir)
 	recombine(destdir, sdump)


### PR DESCRIPTION
When file path containing slash, fail in mkdtemp.
This patch fix it.

```
% pgdump-sort ../dump.sql
Traceback (most recent call last):
  File "pgdump-sort", line 181, in <module>
    pgdump_sort(dump, sdump)
  File "pgdump-sort", line 165, in pgdump_sort
    destdir = tempfile.mkdtemp(suffix=dump, prefix='pgdump-sort')
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/tempfile.py", line 359, in mkdtemp
    _os.mkdir(file, 0o700)
FileNotFoundError: [Errno 2] No such file or directory: '/var/folders/__/1sw5pln95tl8lj35dvbh1cth0000gn/T/pgdump-sortx20fel2r../dump.sql'
```

Environment:

* Python v3.8.2
* MacOS v11.3.1 (Darwin Kernel Version 20.4.0)
